### PR TITLE
Release/0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.0
+
+* [**Backwards incompatible change**]<br>
+Move the `path_to()`, `log()`, `load_image()` and `load_font()` methods of
+the `Game` class to be functions of a new `pygametemplate.core` module.
+`log()`, `load_image()` and `load_font()` are also accessible as direct
+members of the `pygametemplate` module.
+
+* [**Backwards incompatible change**]<br>
+Remove `pygametemplate.helper.Helper` class and move its methods to
+be functions as members of the `pygametemplate.helper` module.
+`Game` instances no longer have a `helper` attribute, meaning that all
+references to `game.helper.method()` will have to be replaced with
+`pygametemplate.helper.method()`.
+
+
 ## 0.3.0
 
 * [**Backwards incompatible change**]<br>
@@ -9,7 +25,6 @@ Every view should inherit from `pygametemplate.View`.
 All `View`s have a `self.game` member for accessing the main `Game` instance.
 To switch to the next view in your game, you can call `self.game.set_view(NextViewClass)`.
 `View` classes are expected to implement the following methods:
-
     * `View.load(self)`: load all the assets/other things needed for the view to work.
     This means you only load images (for example) into RAM when you need them.
 
@@ -21,7 +36,6 @@ To switch to the next view in your game, you can call `self.game.set_view(NextVi
 
     * `View.draw(self)`: run all drawing code for the view.
 
-
 * Change `_inputs()`, `_update()` and `_check_quit()` to be "private" methods
 of the `Game` class by prepending an underscore to their names.
 
@@ -29,6 +43,7 @@ of the `Game` class by prepending an underscore to their names.
 (defaults to `ctrl+f`) so that it can be customised.
 
 * Add 1280x720 as the default window resolution if one isn't passed in.
+
 
 ## 0.2.0
 

--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -4,11 +4,6 @@
 
 * Add `pygametemplate.additional` module with `DebugConsole` class.
 
-* Change `helper.Helper` to be a module instead of a class.
-
-* Move methods of `Game` which don't affect its state to a module
-so that game doesn't need to be passed around? Like file loading maybe.
-
 * `Image` class with `Image.display(pygame.Surface())` method,
 along with loading and unloading from RAM.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.3.0#{build}
+version: 0.4.0#{build}
 
 environment:
   CODACY_PROJECT_TOKEN:

--- a/debug.py
+++ b/debug.py
@@ -6,5 +6,5 @@ from example_view import ExampleView
 
 
 if __name__ == "__main__":
-        game = ExampleGame(ExampleView)
-        game.run()
+    game = ExampleGame(ExampleView)
+    game.run()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import traceback
 
 from example_game import ExampleGame
 from example_view import ExampleView
+from pygametemplate import log
 from pygametemplate.exceptions import CaughtFatalException
 
 if __name__ == "__main__":
@@ -23,4 +24,4 @@ if __name__ == "__main__":
         except CaughtFatalException:
             pass
         except Exception: # Catches all exceptions that weren't caught in the rest of the code
-            game.log("UNCAUGHT FATAL EXCEPTION")
+            log("UNCAUGHT FATAL EXCEPTION")

--- a/pygametemplate/__init__.py
+++ b/pygametemplate/__init__.py
@@ -11,5 +11,6 @@ __author__ = "Andrew Dean"
 __author_email__ = "oneandydean@hotmail.com"
 
 
+from pygametemplate.core import log
 from pygametemplate.game import Game
 from pygametemplate.view import View

--- a/pygametemplate/__init__.py
+++ b/pygametemplate/__init__.py
@@ -11,6 +11,6 @@ __author__ = "Andrew Dean"
 __author_email__ = "oneandydean@hotmail.com"
 
 
+from pygametemplate.core import log, load_image, load_font
 from pygametemplate.game import Game
 from pygametemplate.view import View
-from pygametemplate.core import log, load_image, load_font

--- a/pygametemplate/__init__.py
+++ b/pygametemplate/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __url__ = "https://github.com/AndyDeany/pygame-template"
 __download_url__ = "{}/archive/v{}.tar.gz".format(__url__, __version__)

--- a/pygametemplate/__init__.py
+++ b/pygametemplate/__init__.py
@@ -11,6 +11,6 @@ __author__ = "Andrew Dean"
 __author_email__ = "oneandydean@hotmail.com"
 
 
-from pygametemplate.core import log
 from pygametemplate.game import Game
 from pygametemplate.view import View
+from pygametemplate.core import log, load_image, load_font

--- a/pygametemplate/button.py
+++ b/pygametemplate/button.py
@@ -1,5 +1,8 @@
 import time
 
+from pygametemplate import log
+
+
 class Button(object):
     """Class representing keyboard keys."""
     def __init__(self, game, number):
@@ -13,7 +16,7 @@ class Button(object):
             self.released = 0   # If the button was just released
             self.press_time = 0.0
         except Exception:
-            self.game.log("Failed to initialise button variable")
+            log("Failed to initialise button variable")
 
     def press(self):
         self.pressed = 1
@@ -29,7 +32,7 @@ class Button(object):
             self.pressed = 0
             self.released = 0
         except Exception:
-            self.game.log("Failed to reset button")
+            log("Failed to reset button")
 
     def time_held(self):
         try:
@@ -38,4 +41,4 @@ class Button(object):
             else:
                 return 0.0
         except Exception:
-            self.game.log("Failed to get button held time")
+            log("Failed to get button held time")

--- a/pygametemplate/console.py
+++ b/pygametemplate/console.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-
+from pygametemplate import log
 from pygametemplate.hotkey import Hotkey
+
 
 class Console(object):
 
@@ -24,7 +25,7 @@ class Console(object):
                 "toggle fps": (toggle_fps_hotkey.pressed, self.toggle_fps)
             }
         except Exception:
-            self.game.log("Failed to initialise console object")
+            log("Failed to initialise console object")
 
     def logic(self):
         for condition, function in self.hotkeys.values():
@@ -45,4 +46,4 @@ class Console(object):
                 True, self.text_colour
                 ), self.fps_coordinates)
         except Exception:
-            self.game.log("Failed to display FPS")
+            log("Failed to display FPS")

--- a/pygametemplate/core.py
+++ b/pygametemplate/core.py
@@ -32,3 +32,30 @@ def log(*error_message, fatal=True):
         raise CaughtFatalException(sys.exc_info()[1])
     else:
         pass    # TODO: Add some code here to show an error message in game
+
+
+# Asset loading
+def load_image(image_name, fade_enabled=False, file_extension=".png"):
+    """fade_enabled should be True if you want images to be able to fade"""
+    try:
+        #! Add stuff for loading images of the correct resolution
+        # depending on the player's resolution settings
+        if not fade_enabled:
+            return pygame.image.load(
+                path_to("assets/images", image_name + file_extension)
+            ).convert_alpha()   # Fixes per pixel alphas permanently
+        else:
+            return pygame.image.load(
+                path_to("assets/images", image_name + file_extension)
+            ).convert()
+    except Exception:
+        log("Failed to load image: ", image_name, file_extension)
+
+
+def load_font(font_name, font_size, file_extension=".ttf"):
+    try:
+        return pygame.font.Font(
+            path_to("assets/fonts", font_name + file_extension), font_size
+        )
+    except Exception:
+        log("Failed to load font: ", font_name, file_extension)

--- a/pygametemplate/core.py
+++ b/pygametemplate/core.py
@@ -3,7 +3,7 @@ import os
 import sys
 import traceback
 from datetime import datetime
-from ctypes import windll
+import ctypes
 
 from pygametemplate.exceptions import CaughtFatalException
 
@@ -29,7 +29,7 @@ def log(*error_message, **options):
     if fatal:
         text = ("An error has occurred:\n\n    {}.\n\n\n"
                 "Please check log.txt for details.").format(error_message)
-        windll.user32.MessageBoxW(0, text, "Error", 0)
+        ctypes.windll.user32.MessageBoxW(0, text, "Error", 0)
         raise CaughtFatalException(sys.exc_info()[1])
     else:
         pass    # TODO: Add some code here to show an error message in game

--- a/pygametemplate/core.py
+++ b/pygametemplate/core.py
@@ -1,0 +1,34 @@
+"""Module containing the core functions of pygametemplate."""
+import os
+import sys
+import traceback as traceback
+from datetime import datetime
+import ctypes as ctypes
+
+from pygametemplate.exceptions import CaughtFatalException
+
+
+PATH = os.getcwd()
+
+
+def path_to(*path):
+    """Returns the complete absolute path of the path given."""
+    return os.path.join(PATH, *"/".join(path).split("/"))
+
+
+LOG_FILE = path_to("log.txt")
+
+def log(*error_message, fatal=True):
+    """Takes 1 or more variables and concatenates them to create the error message."""
+    error_message = "".join(map(str, error_message))
+    with open(LOG_FILE, "a") as log_file:
+        log_file.write("{} - {}.\n".format(datetime.utcnow(), error_message))
+        log_file.write(traceback.format_exc() + "\n")
+
+    if fatal:
+        text = ("An error has occurred:\n\n    {}.\n\n\n"
+                "Please check log.txt for details.").format(error_message)
+        ctypes.windll.user32.MessageBoxA(0, text, "Error", 0)   # Error popup
+        raise CaughtFatalException(sys.exc_info()[1])
+    else:
+        pass    # TODO: Add some code here to show an error message in game

--- a/pygametemplate/core.py
+++ b/pygametemplate/core.py
@@ -1,9 +1,9 @@
 """Module containing the core functions of pygametemplate."""
 import os
 import sys
-import traceback as traceback
+import traceback
 from datetime import datetime
-import ctypes as ctypes
+from ctypes import windll
 
 from pygametemplate.exceptions import CaughtFatalException
 
@@ -28,7 +28,7 @@ def log(*error_message, fatal=True):
     if fatal:
         text = ("An error has occurred:\n\n    {}.\n\n\n"
                 "Please check log.txt for details.").format(error_message)
-        ctypes.windll.user32.MessageBoxA(0, text, "Error", 0)   # Error popup
+        windll.user32.MessageBoxW(0, text, "Error", 0)
         raise CaughtFatalException(sys.exc_info()[1])
     else:
         pass    # TODO: Add some code here to show an error message in game

--- a/pygametemplate/core.py
+++ b/pygametemplate/core.py
@@ -18,8 +18,9 @@ def path_to(*path):
 
 LOG_FILE = path_to("log.txt")
 
-def log(*error_message, fatal=True):
+def log(*error_message, **options):
     """Takes 1 or more variables and concatenates them to create the error message."""
+    fatal = options.get("fatal", True)  # `fatal` option defaults to True
     error_message = "".join(map(str, error_message))
     with open(LOG_FILE, "a") as log_file:
         log_file.write("{} - {}.\n".format(datetime.utcnow(), error_message))

--- a/pygametemplate/exceptions.py
+++ b/pygametemplate/exceptions.py
@@ -1,3 +1,3 @@
 class CaughtFatalException(Exception):
-    """Raised by Game.log() when it catches a fatal exception."""
+    """Raised by pygametemplate.core.log() when it catches a fatal exception."""
     pass

--- a/pygametemplate/game.py
+++ b/pygametemplate/game.py
@@ -88,9 +88,8 @@ class Game(object):
         """Returns the complete absolute path of the path given."""
         return os.path.join(self.directory, *"/".join(path).split("/"))
 
-    def log(self, *error_message, **options):
+    def log(self, *error_message, fatal=True):
         """Takes 1 or more variables and concatenates them to create the error message."""
-        fatal = options.get("fatal", True)  # `fatal` option defaults to True
         error_message = "".join(map(str, error_message))
         try:
             with open(self.path_to("log.txt"), "a") as error_log:

--- a/pygametemplate/game.py
+++ b/pygametemplate/game.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     pass
 
-from pygametemplate import log
+from pygametemplate import log, load_image
 from pygametemplate.system import System
 from pygametemplate.helper import Helper
 from pygametemplate.console import Console
@@ -33,7 +33,7 @@ class Game(object):
         self.mode = mode
         self.initialise_screen()
         pygame.display.set_caption("insertnamehere (Alpha 1.0)")
-        #! pygame.display.set_icon(self.load_image("icon_name", file_extension=".ico"))
+        #! pygame.display.set_icon(load_image("icon_name", file_extension=".ico"))
 
         self.last_view = None
         self.current_view = StartingView(self)

--- a/pygametemplate/game.py
+++ b/pygametemplate/game.py
@@ -103,31 +103,6 @@ class Game(object):
             log("Failed to reinitialise screen in ", mode, " mode "
                      "at ", self.width, "x", self.height, " resolution")
 
-    # Asset loading
-    def load_image(self, image_name, fade_enabled=False, file_extension=".png"):
-        """fade_enabled should be True if you want images to be able to fade"""
-        try:
-            #! Add stuff for loading images of the correct resolution
-            # depending on the player's resolution settings
-            if not fade_enabled:
-                return pygame.image.load(
-                    self.path_to("assets/images", image_name + file_extension)
-                    ).convert_alpha()   # Fixes per pixel alphas permanently
-            else:
-                return pygame.image.load(
-                    self.path_to("assets/images", image_name + file_extension)
-                    ).convert()
-        except Exception:
-            log("Failed to load image: ", image_name, file_extension)
-
-    def load_font(self, font_name, font_size, file_extension=".ttf"):
-        try:
-            return pygame.font.Font(
-                self.path_to("assets/fonts", font_name + file_extension), font_size
-                )
-        except Exception:
-            log("Failed to load font: ", font_name, file_extension)
-
     def display(self, image, coordinates, area=None, special_flags=0):
         """Takes coordinates and area for a 1920x1080 window"""
         try:

--- a/pygametemplate/game.py
+++ b/pygametemplate/game.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from pygametemplate import log, load_image
 from pygametemplate.system import System
-from pygametemplate.helper import Helper
 from pygametemplate.console import Console
 from pygametemplate.userinput import Input
 from pygametemplate.hotkey import Hotkey
@@ -42,7 +41,6 @@ class Game(object):
         self.frame = 0  # The current frame the game is on (since the game was opened)
 
         self.input = Input(self)
-        self.helper = Helper(self)
         self.console = Console(self)
 
         self.quit_condition = Hotkey(self, "f4", alt=True).pressed

--- a/pygametemplate/game.py
+++ b/pygametemplate/game.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 
 
 import os
-import sys
-import ctypes
-import traceback
-import datetime
 import time
 
 import pygame
@@ -16,7 +12,7 @@ try:
 except ImportError:
     pass
 
-from pygametemplate.exceptions import CaughtFatalException
+from pygametemplate import log
 from pygametemplate.system import System
 from pygametemplate.helper import Helper
 from pygametemplate.console import Console
@@ -27,13 +23,11 @@ from pygametemplate.text_input import TextInput
 
 class Game(object):
     def __init__(self, StartingView, resolution=(1280, 720), mode="windowed"):
-        self.directory = os.getcwd()
-
         try:
             pygame.init()
             self.pygame = pygame
         except Exception:
-            self.log("Failed to initialise pygame")
+            log("Failed to initialise pygame")
         self.system = System(self)
         self.width, self.height = resolution
         self.mode = mode
@@ -84,31 +78,6 @@ class Game(object):
         self.quit()
         pygame.quit()
 
-    def path_to(self, *path):
-        """Returns the complete absolute path of the path given."""
-        return os.path.join(self.directory, *"/".join(path).split("/"))
-
-    def log(self, *error_message, fatal=True):
-        """Takes 1 or more variables and concatenates them to create the error message."""
-        error_message = "".join(map(str, error_message))
-        try:
-            with open(self.path_to("log.txt"), "a") as error_log:
-                error_log.write("%s - %s.\n" % (datetime.datetime.utcnow(), error_message))
-                error_log.write(traceback.format_exc() + "\n")
-        except Exception:
-            error_info = "This error occurred very early during game initialisation and could not be logged"
-        else:
-            error_info = "Please check log.txt for details"
-
-        if fatal:
-            text = "".join(("An error has occurred:\n\n    ",
-                            error_message, ".\n\n\n",
-                            error_info, "."))
-            ctypes.windll.user32.MessageBoxA(0, text, "Error", 0)   # Error popup
-            raise CaughtFatalException(sys.exc_info()[1])
-        else:
-            pass    #! Add some code here to show an error message in game
-
     def initialise_screen(self, resolution=None, mode=None):
         """(Re)initialises the screen using the given arguments."""
         try:
@@ -131,7 +100,7 @@ class Game(object):
             self.width, self.height = resolution
             self.mode = mode
         except Exception:
-            self.log("Failed to reinitialise screen in ", mode, " mode "
+            log("Failed to reinitialise screen in ", mode, " mode "
                      "at ", self.width, "x", self.height, " resolution")
 
     # Asset loading
@@ -149,7 +118,7 @@ class Game(object):
                     self.path_to("assets/images", image_name + file_extension)
                     ).convert()
         except Exception:
-            self.log("Failed to load image: ", image_name, file_extension)
+            log("Failed to load image: ", image_name, file_extension)
 
     def load_font(self, font_name, font_size, file_extension=".ttf"):
         try:
@@ -157,7 +126,7 @@ class Game(object):
                 self.path_to("assets/fonts", font_name + file_extension), font_size
                 )
         except Exception:
-            self.log("Failed to load font: ", font_name, file_extension)
+            log("Failed to load font: ", font_name, file_extension)
 
     def display(self, image, coordinates, area=None, special_flags=0):
         """Takes coordinates and area for a 1920x1080 window"""
@@ -170,7 +139,7 @@ class Game(object):
                         area[2]*x_scale, area[3]*y_scale)
             self.screen.blit(image, coordinates, area, special_flags)
         except Exception:
-            self.log("Failed to display image at ", coordinates)
+            log("Failed to display image at ", coordinates)
 
     def _inputs(self):
         self.input.reset()
@@ -196,13 +165,13 @@ class Game(object):
             pygame.display.flip()   # Updating the screen
             self.clock.tick(self.fps)    # [fps] times per second
         except Exception:
-            self.log("Failed to update screen")
+            log("Failed to update screen")
 
     def runtime(self):
         try:
             return time.time() - self.start_time
         except Exception:
-            self.log("Failed to calculate and return game run time")
+            log("Failed to calculate and return game run time")
 
     def _check_quit(self):
         if self.quit_condition():
@@ -214,7 +183,7 @@ class Game(object):
             self.clock = pygame.time.Clock()
             self.start_time = time.time()
         except Exception:
-            self.log("Failed to initialise essential time related display variables")
+            log("Failed to initialise essential time related display variables")
 
         while self.running:
             self._inputs()

--- a/pygametemplate/helper.py
+++ b/pygametemplate/helper.py
@@ -1,3 +1,6 @@
+from pygametemplate import log
+
+
 class Helper(object):
     """Class holding helper functions."""
     def __init__(self, game):
@@ -10,7 +13,7 @@ class Helper(object):
                 calling_class = calling_object.__class__
                 setattr(calling_class, attribute_name, assets_dict[attribute_name])
         except Exception:
-            self.game.log("Failed to load ", calling_class.__name__, " class assets")
+            log("Failed to load ", calling_class.__name__, " class assets")
         setattr(calling_class, "class_assets_loaded", True)
 
     def wrap_text(self, text, font, max_width):
@@ -51,5 +54,5 @@ class Helper(object):
             return sum(map(wrap_paragraph, paragraphs), [])
         except Exception as error:
             fatal = not isinstance(error, ValueError)
-            self.game.log("Failed to wrap text: \"", text, "\"", fatal=fatal)
+            log("Failed to wrap text: \"", text, "\"", fatal=fatal)
             return ["error"]

--- a/pygametemplate/helper.py
+++ b/pygametemplate/helper.py
@@ -1,58 +1,54 @@
+"""Module containing helper functions for using pygame."""
 from pygametemplate import log
 
 
-class Helper(object):
-    """Class holding helper functions."""
-    def __init__(self, game):
-        self.game = game
+def load_class_assets(calling_object, assets_dict):
+    """Load class assets. Only call if class_assets_loaded is False."""
+    try:
+        for attribute_name in assets_dict:
+            calling_class = calling_object.__class__
+            setattr(calling_class, attribute_name, assets_dict[attribute_name])
+    except Exception:
+        log("Failed to load ", calling_class.__name__, " class assets")
+    setattr(calling_class, "class_assets_loaded", True)
 
-    def load_class_assets(self, calling_object, assets_dict):
-        """Loads class assets. Should only be calling if self.class_assets_loaded is False."""
-        try:
-            for attribute_name in assets_dict:
-                calling_class = calling_object.__class__
-                setattr(calling_class, attribute_name, assets_dict[attribute_name])
-        except Exception:
-            log("Failed to load ", calling_class.__name__, " class assets")
-        setattr(calling_class, "class_assets_loaded", True)
+def wrap_text(text, font, max_width):
+    """
+    Returns an array of lines which can be blitted beneath each other
+    in the given font in a box of the given maximum width.
+    """
+    def wrap_paragraph(paragraph):
+        """Wraps text that doesn't contain newlines."""
+        def too_long(string):
+            return font.size(string)[0] > max_width
 
-    def wrap_text(self, text, font, max_width):
-        """
-        Returns an array of lines which can be blitted beneath each other
-        in the given font in a box of the given maximum width.
-        """
-        def wrap_paragraph(paragraph):
-            """Wraps text that doesn't contain newlines."""
-            def too_long(string):
-                return font.size(string)[0] > max_width
+        def raise_word_too_long_error(word):
+            raise ValueError("\"%s\" is too long to be wrapped." % word)
 
-            def raise_word_too_long_error(word):
-                raise ValueError("\"%s\" is too long to be wrapped." % word)
+        lines = []
+        words = paragraph.split()
 
-            lines = []
-            words = paragraph.split()
+        line = words.pop(0)
+        if too_long(line):
+            raise_word_too_long_error(line)
 
-            line = words.pop(0)
-            if too_long(line):
-                raise_word_too_long_error(line)
+        for word in words:
+            if too_long(word):
+                raise_word_too_long_error(word)
 
-            for word in words:
-                if too_long(word):
-                    raise_word_too_long_error(word)
+            if too_long(" ".join((line, word))):
+                lines.append(line)
+                line = word
+            else:
+                line = " ".join((line, word))
 
-                if too_long(" ".join((line, word))):
-                    lines.append(line)
-                    line = word
-                else:
-                    line = " ".join((line, word))
+        lines.append(line)
+        return lines
 
-            lines.append(line)
-            return lines
-
-        try:
-            paragraphs = text.split("\n")
-            return sum(map(wrap_paragraph, paragraphs), [])
-        except Exception as error:
-            fatal = not isinstance(error, ValueError)
-            log("Failed to wrap text: \"", text, "\"", fatal=fatal)
-            return ["error"]
+    try:
+        paragraphs = text.split("\n")
+        return sum(map(wrap_paragraph, paragraphs), [])
+    except Exception as error:
+        fatal = not isinstance(error, ValueError)
+        log("Failed to wrap text: \"", text, "\"", fatal=fatal)
+        return ["error"]

--- a/pygametemplate/hotkey.py
+++ b/pygametemplate/hotkey.py
@@ -1,3 +1,6 @@
+from pygametemplate import log
+
+
 class Hotkey(object):
     def __init__(self, game, button_name, ctrl=False, shift=False, alt=False):
         self.game = game
@@ -8,7 +11,7 @@ class Hotkey(object):
             self.shift = shift
             self.alt = alt
         except Exception:
-            self.game.log("Failed to initialise hotkey object")
+            log("Failed to initialise hotkey object")
 
     def pressed(self):
         """Returns True if the hotkey was just pressed."""

--- a/pygametemplate/system.py
+++ b/pygametemplate/system.py
@@ -1,3 +1,6 @@
+from pygametemplate import log
+
+
 class System(object):
     def __init__(self, game):
         self.game = game
@@ -6,4 +9,4 @@ class System(object):
             self.MONITOR_WIDTH = display_info.current_w
             self.MONITOR_HEIGHT = display_info.current_h
         except Exception:
-            self.game.log("Failed to initialise system object")
+            log("Failed to initialise system object")

--- a/pygametemplate/text_input.py
+++ b/pygametemplate/text_input.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
-
 from collections import deque
 
+from pygametemplate import log
 from pygametemplate.hotkey import Hotkey
+
 
 class TextInput(object):
     class_assets_loaded = False
@@ -87,7 +88,7 @@ class TextInput(object):
                      coordinates[1])
                 )
         except Exception:
-            self.game.log("Failed to display text input")
+            log("Failed to display text input")
 
     def check_focused(self, x, y, width, height):
         """
@@ -189,8 +190,8 @@ class TextInput(object):
                     elif len(active_instance.text) < active_instance.max_characters:
                         active_instance.insert_character(event.unicode)
             except Exception:
-                active_instance.game.log("Failed to receive input from a key press"
-                                         "[event.key = ", event.key, "]")
+                log("Failed to receive input from a key press"
+                    "[event.key = ", event.key, "]")
 
     character_keys = (  # Keys that alter the appearance of self.text when it is displayed
         [n for n in range(44, 58)]
@@ -209,7 +210,7 @@ class TextInput(object):
                     if button.time_held() > 0.5:
                         self.receive_single_characters(button.event)
             except Exception:
-                self.game.log("Failed to receive text input from held keys")
+                log("Failed to receive text input from held keys")
 
     @classmethod
     def character_keys_held(self):

--- a/pygametemplate/text_input.py
+++ b/pygametemplate/text_input.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from collections import deque
 
 from pygametemplate import log
+from pygametemplate.helper import load_class_assets
 from pygametemplate.hotkey import Hotkey
 
 
@@ -34,9 +35,7 @@ class TextInput(object):
         self.instances.append(self)
 
     def load_class_assets(self, game):
-        game.helper.load_class_assets(self, {
-            "game": game
-        })
+        load_class_assets(self, {"game": game})
 
     def destroy(self):
         self.instances.remove(self)

--- a/pygametemplate/userinput.py
+++ b/pygametemplate/userinput.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-
+from pygametemplate import log
 from pygametemplate.button import Button
+
 
 class Input(object):
     """
@@ -79,14 +80,14 @@ class Input(object):
             button.press()
             button.event = event
         except Exception:
-            self.game.log("Failed to process a button being pressed"
-                          "[event number=", number, "]")
+            log("Failed to process a button being pressed "
+                "[event number=", number, "]")
 
     def buttonup(self, number):
         try:
             next((button for button in self.buttons.values() if button.number == number)).release()
         except Exception:
-            self.game.log("Failed to process a button being released [event number=", number, "]")
+            log("Failed to process a button being released [event number=", number, "]")
 
     def mousein(self, x, y, width, height):
         """Determines if the mouse is in the given rectangle."""
@@ -94,5 +95,5 @@ class Input(object):
             return (x < self.mouse_pos[0] < x + width and
                     y < self.mouse_pos[1] < y + height)
         except Exception:
-            self.game.log("Unable to determine whether mouse position meet the requirements ",
-                          x, " < x < ", x + width, ", ", y, " < y <  ", y + height)
+            log("Unable to determine whether mouse position meet the requirements ",
+                x, " < x < ", x + width, ", ", y, " < y <  ", y + height)

--- a/spec/core_spec.py
+++ b/spec/core_spec.py
@@ -1,7 +1,9 @@
 """File containing unit tests for the pygametemplate.core module."""
 import os
 
-from spec.helper import *
+from expects import *
+
+from pygametemplate.core import path_to, log, load_image, load_font
 
 
 with description("pygametemplate.core"):
@@ -13,18 +15,18 @@ with description("pygametemplate.core"):
 
         with it("should give a path to a given file in the root directory"):
             expected_path = joined_path_to("file.txt")
-            expect(game.path_to("file.txt")).to(equal(expected_path))
+            expect(path_to("file.txt")).to(equal(expected_path))
 
         with it("should give a path to a file embedded in further folders"):
             expected_path = joined_path_to("folder", "file.txt")
-            expect(game.path_to("folder/file.txt")).to(equal(expected_path))
+            expect(path_to("folder/file.txt")).to(equal(expected_path))
 
         with it("should load a file when given it's location using multiple arguments"):
             expected_path = joined_path_to("folder", "file.txt")
-            expect(game.path_to("folder", "file.txt")).to(equal(expected_path))
+            expect(path_to("folder", "file.txt")).to(equal(expected_path))
 
             expected_path = joined_path_to("folder", "deeper_folder", "file.txt")
-            expect(game.path_to("folder/deeper_folder", "file.txt")).to(equal(expected_path))
+            expect(path_to("folder/deeper_folder", "file.txt")).to(equal(expected_path))
 
     with context(".log()"):
         pass

--- a/spec/core_spec.py
+++ b/spec/core_spec.py
@@ -1,0 +1,36 @@
+"""File containing unit tests for the pygametemplate.core module."""
+import os
+
+from spec.helper import *
+
+
+with description("pygametemplate.core"):
+    with context(".path_to()"):
+        global joined_path_to
+
+        def joined_path_to(*path_elements):
+            return os.path.join(os.getcwd(), *path_elements)
+
+        with it("should give a path to a given file in the root directory"):
+            expected_path = joined_path_to("file.txt")
+            expect(game.path_to("file.txt")).to(equal(expected_path))
+
+        with it("should give a path to a file embedded in further folders"):
+            expected_path = joined_path_to("folder", "file.txt")
+            expect(game.path_to("folder/file.txt")).to(equal(expected_path))
+
+        with it("should load a file when given it's location using multiple arguments"):
+            expected_path = joined_path_to("folder", "file.txt")
+            expect(game.path_to("folder", "file.txt")).to(equal(expected_path))
+
+            expected_path = joined_path_to("folder", "deeper_folder", "file.txt")
+            expect(game.path_to("folder/deeper_folder", "file.txt")).to(equal(expected_path))
+
+    with context(".log()"):
+        pass
+
+    with context(".load_image()"):
+        pass
+
+    with context(".load_font()"):
+        pass

--- a/spec/game_spec.py
+++ b/spec/game_spec.py
@@ -14,10 +14,10 @@ with description("Game"):
     with context(".display()"):
         pass
 
-    with context(".inputs()"):
+    with context("._inputs()"):
         pass
 
-    with context(".update()"):
+    with context("._update()"):
         pass
 
     with context(".runtime()"):

--- a/spec/game_spec.py
+++ b/spec/game_spec.py
@@ -1,5 +1,6 @@
 """File containing unit tests for the pygametemplate.Game class."""
-from spec.helper import *
+from expects import *
+from spec.helper import game
 
 
 with description("Game"):

--- a/spec/game_spec.py
+++ b/spec/game_spec.py
@@ -1,43 +1,13 @@
+"""File containing unit tests for the pygametemplate.Game class."""
 from spec.helper import *
 
-import os
 
 with description("Game"):
     # Uses TestGame which inherits all of game's functions
     with it("should initialise correctly"):
         pass
 
-    with context(".path_to()"):
-        global joined_path_to
-
-        def joined_path_to(*path_elements):
-            return os.path.join(os.getcwd(), *path_elements)
-
-        with it("should give a path to a given file in the root directory"):
-            expected_path = joined_path_to("file.txt")
-            expect(game.path_to("file.txt")).to(equal(expected_path))
-
-        with it("should give a path to a file embedded in further folders"):
-            expected_path = joined_path_to("folder", "file.txt")
-            expect(game.path_to("folder/file.txt")).to(equal(expected_path))
-
-        with it("should load a file when given it's location using multiple arguments"):
-            expected_path = joined_path_to("folder", "file.txt")
-            expect(game.path_to("folder", "file.txt")).to(equal(expected_path))
-
-            expected_path = joined_path_to("folder", "deeper_folder", "file.txt")
-            expect(game.path_to("folder/deeper_folder", "file.txt")).to(equal(expected_path))
-
-    with context(".log()"):
-        pass
-
     with context(".initialise_screen()"):
-        pass
-
-    with context(".load_image()"):
-        pass
-
-    with context(".load_font()"):
         pass
 
     with context(".display()"):

--- a/spec/helper.py
+++ b/spec/helper.py
@@ -7,9 +7,5 @@ class TestGame(Game):
     def __init__(self, StartingView, resolution):
         super(TestGame, self).__init__(StartingView, resolution)
 
-    def log(self, *error_message):
-        """Altered log function which just raises errors."""
-        raise
-
 
 game = TestGame(ExampleView, (1280, 720))

--- a/spec/helper.py
+++ b/spec/helper.py
@@ -1,9 +1,5 @@
-from expects import *
-
-from example_view import ExampleView
 from pygametemplate import Game
-
-import datetime
+from example_view import ExampleView
 
 
 class TestGame(Game):


### PR DESCRIPTION
From the changelog:

* [**Backwards incompatible change**]<br>
Move the `path_to()`, `log()`, `load_image()` and `load_font()` methods of
the `Game` class to be functions of a new `pygametemplate.core` module.
`log()`, `load_image()` and `load_font()` are also accessible as direct
members of the `pygametemplate` module.

* [**Backwards incompatible change**]<br>
Remove `pygametemplate.helper.Helper` class and move its methods to
be functions as members of the `pygametemplate.helper` module.
`Game` instances no longer have a `helper` attribute, meaning that all
references to `game.helper.method()` will have to be replaced with
`pygametemplate.helper.method()`.

Other changes:

* Amend unit tests to match above changes.

* Tidy up imports in unit tests.