### PR TITLE
Release/0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 
+## 0.8.2
+
+* Change `Game.set_view()` to take `view_name: str` instead of
+`View: pygametemplate.View`, as taking a `View` class meant that
+other `View` classes needed to import each other, which was causing
+circular imports, and thus erroring code. This was considered to be a bug as
+views could not switch between each other before. `View` classes are now expected
+to be members of the `lib.views` module in your project. You can change this
+by setting the `VIEW_MODULE` attribute of your `Game` subclass.
+Alternatively, you can override the `Game.get_view_class(view_name: str)`
+method of your `Game` subclass to have your own custom
+view name -> View class conversion functionality.
+
+
 ## 0.8.1
 
 * Fix a bug where using `pygame` functions in your `StartingView`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.8.1#{build}
+version: 0.8.2#{build}
 
 build: off
 

--- a/pygametemplate/_game.py
+++ b/pygametemplate/_game.py
@@ -1,5 +1,6 @@
 import os
 import time
+from importlib import import_module
 
 import pygame
 try:
@@ -21,6 +22,8 @@ pygame.init()
 
 
 class Game:
+
+    VIEW_MODULE = "lib.views"
 
     def __init__(self, StartingView, resolution=(1280, 720), mode="windowed",
                  *, caption="Insert name here v0.1.0", icon=None):
@@ -48,11 +51,16 @@ class Game:
 
         self.quit_condition = Hotkey(self, "f4", alt=True).pressed
 
-    def set_view(self, View):
-        """Set the current view to the given View class."""
+    def set_view(self, view_name: str):
+        """Set the current view to the View class with the given name."""
         self.last_view = self.current_view
         self.last_view.unload()
+        View = self.get_view_class(view_name)
         self.current_view = View(self)
+
+    def get_view_class(view_name: str):
+        """Return the View class with the given view_name."""
+        return getattr(import_module(self.VIEW_MODULE), view_name)
 
     def logic(self):
         raise NotImplementedError

--- a/pygametemplate/_game.py
+++ b/pygametemplate/_game.py
@@ -55,7 +55,7 @@ class Game:
         """Set the current view to the View class with the given name."""
         self.last_view = self.current_view
         self.last_view.unload()
-        View = self.get_view_class(view_name)
+        View = self.get_view_class(view_name)   # pylint: disable=invalid-name
         self.current_view = View(self)
 
     def get_view_class(self, view_name: str):

--- a/pygametemplate/_game.py
+++ b/pygametemplate/_game.py
@@ -58,7 +58,7 @@ class Game:
         View = self.get_view_class(view_name)
         self.current_view = View(self)
 
-    def get_view_class(view_name: str):
+    def get_view_class(self, view_name: str):
         """Return the View class with the given view_name."""
         return getattr(import_module(self.VIEW_MODULE), view_name)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.8.1"
+version = "0.8.2"
 url = "https://github.com/AndyDeany/pygame-template"
 
 with open("requirements.txt", "r") as requirements_file:


### PR DESCRIPTION
Changelog:

* Change `Game.set_view()` to take `view_name: str` instead of
`View: pygametemplate.View`, as taking a `View` class meant that
other `View` classes needed to import each other, which was causing
circular imports, and thus erroring code. This was considered to be a bug as
views could not switch between each other before. `View` classes are now expected
to be members of the `lib.views` module in your project. You can change this
by setting the `VIEW_MODULE` attribute of your `Game` subclass.
Alternatively, you can override the `Game.get_view_class(view_name: str)`
method of your `Game` subclass to have your own custom
view name -> View class conversion functionality.