### PR TITLE
Release/0.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 log.txt
+build/
+dist/
+pygametemplate.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Changelog
 
 
+# 0.9.2
+
+* Fix bug which caused the game to crash when a single view used up
+more than `game.max_allowed_ram`.
+
+* Fix default `max_allowed_ram` to be 1GB as it was supposed to be.
+It was incorrectly set to 1B in previous versions.
+
+
 # 0.9.1
+
+**Warning**: This version has a bug in it meaning its functionality is
+limited. Please use version 0.9.2 instead.
 
 * Fix fatal bug (bad reference) in `Game.set_view()` that caused a crash 100% of the time.
 
@@ -9,7 +21,7 @@
 ## 0.9.0
 
 **Warning**: This version has a fatal bug in it meaning its functionality is
-severly limited. Please use version 0.9.1 instead.
+severly limited. Please use version 0.9.2 instead.
 
 * Rename `Game.quit()` to `Game.on_quit()` and make it optional to implement.
 If you want to add custom functionality, you can now define the `on_quit()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ If you want to add custom functionality, you can now define the `on_quit()`
 method on your `Game` subclass.
 
 * Add new `Game.quit()` method which signals the game to exit.
+**Be sure not to override this method: there is a high chance you already
+have, as this was required in previous versions.**
 
 * Add new `Game.get_memory_use() -> int` method which returns the current
 memory usage of the game (RSS) in bytes.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.9.1#{build}
+version: 0.9.2#{build}
 
 build: off
 

--- a/pygametemplate/_game.py
+++ b/pygametemplate/_game.py
@@ -27,7 +27,7 @@ class Game:
 
     def __init__(self, StartingView, resolution=(1280, 720), mode="windowed",
                  *, caption="Insert name here v0.1.0", icon=None,
-                 max_allowed_ram=1**30):
+                 max_allowed_ram=1 * 2**30):
         """Create a new Game object.
 
         `icon` should be the name of an image file.
@@ -65,7 +65,7 @@ class Game:
         else:
             self.current_view = View(self)
 
-        while self.get_memory_use() > self.max_allowed_ram:
+        while self.previous_views and self.get_memory_use() > self.max_allowed_ram:
             oldest_view = self.previous_views.pop(0)
             oldest_view.unload()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "0.9.1"
+version = "0.9.2"
 url = "https://github.com/AndyDeany/pygame-template"
 
 with open("requirements.txt", "r") as requirements_file:


### PR DESCRIPTION
From changelog:

* Fix bug which caused the game to crash when a single view used up more than `game.max_allowed_ram`.

* Fix default `max_allowed_ram` to be 1GB as it was supposed to be. It was incorrectly set to 1B in previous versions.

---

Other changes:

* Add locations of build artefacts (from `python setup.py bdist_wheel`) to `.gitignore`.

* Clarification in changelog about the changes to `Game().quit()` in version 0.9.0.